### PR TITLE
Use python-build rather than pyenv.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM node:$NODE_IMAGE_TAG
 
 ARG PYTHON_VERSION
 
-ENV PYENV_ROOT="/usr/local/share/pyenv"
-
 RUN apk add --no-cache bash git \
   && apk add --no-cache --virtual build-deps \
     build-base \
@@ -16,13 +14,12 @@ RUN apk add --no-cache bash git \
     readline-dev \
     sqlite-dev \
     linux-headers \
-  && git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-  && echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /etc/profile.d/pyenv.sh \
-  && echo 'eval "$(pyenv init -)"' >> /etc/profile.d/pyenv.sh \
-  && chmod a+x /etc/profile.d/pyenv.sh \
-  && source /etc/profile.d/pyenv.sh \
-  && pyenv install $PYTHON_VERSION \
-  && pyenv global $PYTHON_VERSION \
-  && apk del build-deps
+  && cd /tmp \
+  && git clone git://github.com/pyenv/pyenv.git \
+  && cd pyenv/plugins/python-build \
+  && ./install.sh \
+  && cd /tmp \
+  && rm -rf pyenv \
+  && python-build $PYTHON_VERSION /usr/local
 
-CMD sh -l
+CMD sh


### PR DESCRIPTION
Why:

* python-build allows us to build python and it's tools to a location in
  the main path (i.e. /usr/local) rather than have to load pyenv shims
  that make it so pyenv details leak and affect consumers of this image.

This change addresses the need by:

* Install python-build
* Install python with python-build to /usr/local

Side effects:

* Python and it's tools are installed into /usr/local